### PR TITLE
Seed is unused and may cause compilation to fail

### DIFF
--- a/src/folsom_sample_uniform.erl
+++ b/src/folsom_sample_uniform.erl
@@ -47,7 +47,7 @@ update(#uniform{size = Size, reservoir = Reservoir, n = N} = Sample, Value) when
     ets:insert(Reservoir, {N, Value}),
     Sample#uniform{n = N + 1};
 
-update(#uniform{reservoir = Reservoir, size = Size, n = N, seed = Seed} = Sample,
+update(#uniform{reservoir = Reservoir, size = Size, n = N} = Sample,
        Value) ->
     Rnd= rand:uniform(N),
     maybe_update(Rnd, Size, Value, Reservoir),


### PR DESCRIPTION
Should speak to itself but depending on how strict your rebar.config is, compilation may fail due to unused variables. I considered using _Seed but it feels kinda silly in this case. If you disagree, tell me and I'll change :) 